### PR TITLE
prevent runtime using garbage value from heap

### DIFF
--- a/src/CommonAPI/Runtime.cpp
+++ b/src/CommonAPI/Runtime.cpp
@@ -77,7 +77,7 @@ Runtime::Runtime()
       defaultFolder_(COMMONAPI_DEFAULT_FOLDER),
       isConfigured_(false),
       isInitialized_(false),
-      defaultCallTimeout_(CommonAPI::DEFAULT_SEND_TIMEOUT_MS) {
+      defaultCallTimeout_(DEFAULT_SEND_TIMEOUT_MS) {
 }
 
 Runtime::~Runtime() {

--- a/src/CommonAPI/Runtime.cpp
+++ b/src/CommonAPI/Runtime.cpp
@@ -14,6 +14,7 @@
 
 #include <algorithm>
 
+#include <CommonAPI/Config.hpp>
 #include <CommonAPI/Factory.hpp>
 #include <CommonAPI/IniFileReader.hpp>
 #include <CommonAPI/Logger.hpp>
@@ -75,7 +76,8 @@ Runtime::Runtime()
     : defaultBinding_(COMMONAPI_DEFAULT_BINDING),
       defaultFolder_(COMMONAPI_DEFAULT_FOLDER),
       isConfigured_(false),
-      isInitialized_(false) {
+      isInitialized_(false),
+      defaultCallTimeout_(CommonAPI::DEFAULT_SEND_TIMEOUT_MS) {
 }
 
 Runtime::~Runtime() {


### PR DESCRIPTION
Without a commonapi.ini configuration file, the capi runtime uses garbage values ​​from heap memory.

And if we use the default value for CallInfo.timeout, the garbage timeout value defined above will be used.
https://github.com/sonatus/snt-capicxx-core-runtime/blob/89720d3c63bbd22cbccc80cdc92c2f2dd20193ba/src/CommonAPI/CallInfo.cpp#L29C58-L29C58